### PR TITLE
chore: improve MkDocs configuration

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,10 @@
 site_name: Renovate Docs
 site_url: 'https://docs.renovatebot.com'
+site_description: 'Renovate documentation.'
 
 remote_branch: main
+
+strict: true
 
 # Theme settings
 theme:


### PR DESCRIPTION
## Changes:

- Use `site_description` to add a meta tag to head in HTML [^mkdocs-site-description]
- Use `strict` mode: halt processing when a warning is raised [^mkdocs-strict]

## Context:

I noticed we don't have any site description in our Renovate docs HTML head section right now, so we might want to add a generic description here.

While browsing the MkDocs documentation I saw that they have a `strict` mode, it will complain if you mess up the `mkdocs.yml` config file when doing local work. I think having the program complain and abort is better than silently eating any errors, but maybe you want the publishing of the docs to continue whatever happens.

Not closing any issue with this PR.

[^mkdocs-site-description]: https://www.mkdocs.org/user-guide/configuration/#site_description
[^mkdocs-strict]: https://www.mkdocs.org/user-guide/configuration/#strict